### PR TITLE
Features/security

### DIFF
--- a/gandi_pyramid_prometheus/tests/test_integration.py
+++ b/gandi_pyramid_prometheus/tests/test_integration.py
@@ -1,14 +1,59 @@
-from __future__ import unicode_literals
 from unittest import TestCase
 import time
 
 from webtest import TestApp
+
+from pyramid.security import (Everyone, Authenticated, Allow, Deny,
+                              NO_PERMISSION_REQUIRED,
+                              )
+from pyramid.interfaces import IAuthenticationPolicy
+from pyramid.authorization import ACLAuthorizationPolicy
+from zope.interface import implementer
+
 from gandi_pyramid_prometheus import prometheus as prom
 from prometheus_client import REGISTRY
 from prometheus_client.parser import text_string_to_metric_families
 
 
-def get_app():
+class Context(object):
+    __acl__ = [
+        (Allow, Everyone, NO_PERMISSION_REQUIRED),
+        (Allow, 'metrics', ['prometheus:metric:read']),
+        (Allow, 'user', ['authenticated']),
+        ]
+
+    def __init__(self, request):
+        pass
+
+
+@implementer(IAuthenticationPolicy)
+class AuthenticationPolicy(object):
+
+    def authenticated_userid(self, request):
+        authorization = request.headers.get('Authorization')
+        if authorization == 'Bearer prometheus':
+            return 'prometheus'
+        return 'user'
+
+    def effective_principals(self, request):
+        account = self.authenticated_userid(request)
+        if account == 'prometheus':
+            return ['metrics']
+        elif account == 'user':
+            return ['authenticated']
+        return []
+
+    def unauthenticated_userid(self, request):
+        return request.headers.get('Authorization')
+
+    def remember(self, request):
+        return []
+
+    def forget(self, request):
+        return []
+
+
+def get_app(settings, with_acl=False):
     """
     Return a wsgi application that use the gandi_pyramid_prometheus plugin
     """
@@ -16,16 +61,17 @@ def get_app():
     from pyramid.config import Configurator
     from pyramid.response import Response
 
-    settings = {
-        'prometheus.metric_path_info': '/obfuscated',
-        'prometheus.pyramid_request.buckets': '0.001, 0.1'
-    }
-
     def hello_world(request):
         time.sleep(0.002)
         return Response('Hello {}!'.format(request.matchdict['name']))
 
     with Configurator(settings=settings) as config:
+
+        if with_acl:
+            config.set_root_factory(Context)
+            config.set_authorization_policy(ACLAuthorizationPolicy())
+            config.set_authentication_policy(AuthenticationPolicy())
+
         config.include('gandi_pyramid_prometheus')
         config.add_route('hello', '/hello/{name}')
         config.add_view(hello_world, route_name='hello')
@@ -33,11 +79,14 @@ def get_app():
     return app
 
 
-class IntegrationTestCase(TestCase):
+class MetricsTestCase(TestCase):
 
     def setUp(self):
         self.maxDiff = None
-        app = get_app()
+        settings = {
+            'prometheus.pyramid_request.buckets': '0.001, 0.1'
+        }
+        app = get_app(settings)
         self.app = TestApp(app)
 
     def tearDown(self):
@@ -55,7 +104,7 @@ class IntegrationTestCase(TestCase):
         self.app.post('/hello/Chris')
         self.app.post('/hello/McDonough')
 
-        resp = self.app.get('/obfuscated')
+        resp = self.app.get('/metrics')
 
         metrics = {
             metric.name: metric
@@ -70,15 +119,15 @@ class IntegrationTestCase(TestCase):
 
         self.assertEqual(
             pyramid_request_ingress[('GET', '/hello/{name}')],
-            0.0, # The metrics calls done during the tests is here
+            0.0,  # The metrics calls done during the tests is here
             )
         self.assertEqual(
             pyramid_request_ingress[('POST', '/hello/{name}')],
             0.0,
             )
         self.assertEqual(
-            pyramid_request_ingress[('GET', '/obfuscated')],
-            1.0, # The metrics calls done during the tests is here
+            pyramid_request_ingress[('GET', '/metrics')],
+            1.0,  # The metrics calls done during the tests is here
             )
 
         request_bucket = {
@@ -118,14 +167,14 @@ class IntegrationTestCase(TestCase):
         )
 
         self.assertNotIn(
-            (u'GET', u'/obfuscated', u'200', u'+Inf'),
+            (u'GET', u'/metrics', u'200', u'+Inf'),
             request_bucket,
             "The metrics route has not been call before the capture, "
             "and should bot be present"
         )
 
         # rescrape to get the previous metrics happen
-        resp = self.app.get('/obfuscated')
+        resp = self.app.get('/metrics')
 
         metrics = {
             metric.name: metric
@@ -142,7 +191,7 @@ class IntegrationTestCase(TestCase):
         }
 
         self.assertIn(
-            (u'GET', u'/obfuscated', u'200', u'+Inf'), request_bucket)
+            (u'GET', u'/metrics', u'200', u'+Inf'), request_bucket)
 
         request_count = {
             (sample.labels['method'],
@@ -156,6 +205,37 @@ class IntegrationTestCase(TestCase):
             request_count,
             {(u'POST', u'/hello/{name}', u'200'): 2.0,
              (u'GET', u'/hello/{name}', u'200'): 1.0,
-             (u'GET', u'/obfuscated', u'200'): 1.0,
+             (u'GET', u'/metrics', u'200'): 1.0,
              }
         )
+
+
+class SecurityTestCase(TestCase):
+
+    def setUp(self):
+        settings = {
+            'pyramid.debug_authorization': 'true',
+            'prometheus.metric_path_info': '/obfuscated',
+            'prometheus.pyramid_request.buckets': '0.001, 0.1'
+        }
+        app = get_app(settings, with_acl=True)
+        self.app = TestApp(app)
+
+    def tearDown(self):
+        self.app = None
+        if prom.pyramid_request:
+            REGISTRY.unregister(prom.pyramid_request)
+            prom.pyramid_request = None
+
+        if prom.pyramid_request_ingress:
+            REGISTRY.unregister(prom.pyramid_request_ingress)
+            prom.pyramid_request_ingress = None
+
+    def test_403(self):
+        resp = self.app.get('/obfuscated', expect_errors=True)
+        self.assertEqual(resp.status_code, 403)
+
+    def test_200(self):
+        resp = self.app.get(
+            '/obfuscated', headers={'Authorization': 'Bearer prometheus'})
+        self.assertEqual(resp.status_code, 200)

--- a/gandi_pyramid_prometheus/view.py
+++ b/gandi_pyramid_prometheus/view.py
@@ -31,8 +31,10 @@ def get_metrics(request):
 
 def includeme(config):
     """Configure the /metrics view"""
+    metric_path_info = config.registry.settings.get(
+        'prometheus.metric_path_info', '/metrics')
 
-    config.add_route('prometheus_metric', '/metrics')
+    config.add_route('prometheus_metric', metric_path_info)
     config.add_view(
         get_metrics,
         route_name='prometheus_metric',

--- a/gandi_pyramid_prometheus/view.py
+++ b/gandi_pyramid_prometheus/view.py
@@ -36,5 +36,5 @@ def includeme(config):
     config.add_view(
         get_metrics,
         route_name='prometheus_metric',
-        permission=NO_PERMISSION_REQUIRED,  # XXX FIXME
+        permission='prometheus:metric:read',  # XXX FIXME
         )

--- a/gandi_pyramid_prometheus/view.py
+++ b/gandi_pyramid_prometheus/view.py
@@ -38,5 +38,5 @@ def includeme(config):
     config.add_view(
         get_metrics,
         route_name='prometheus_metric',
-        permission='prometheus:metric:read',  # XXX FIXME
+        permission='prometheus:metric:read',
         )

--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,7 @@ requires = [
 
 extras_require = {
     'doc': [],   # TODO
-    'test': ['webtest'],
+    'test': ['webtest', 'zope.interface'],
 }
 
 setup(name=name,


### PR DESCRIPTION
Add many ways to securize the /metrics route access.

 * Make the route unpredictable via changing the path info

 * Let the application that use the plugin to configure the security access under the permission `prometheus:metric:read`

 * I plan to add resctriction on `X-Forwarded-For` to ensure metrics are collected on service, not on load
balancer.