### PR TITLE
Rename setting for concistancy

### DIFF
--- a/gandi_pyramid_prometheus/tests/test_integration.py
+++ b/gandi_pyramid_prometheus/tests/test_integration.py
@@ -215,7 +215,7 @@ class SecurityTestCase(TestCase):
     def setUp(self):
         settings = {
             'pyramid.debug_authorization': 'true',
-            'prometheus.metric_path_info': '/obfuscated',
+            'prometheus.metrics_path_info': '/obfuscated',
             'prometheus.pyramid_request.buckets': '0.001, 0.1'
         }
         app = get_app(settings, with_acl=True)

--- a/gandi_pyramid_prometheus/view.py
+++ b/gandi_pyramid_prometheus/view.py
@@ -31,10 +31,10 @@ def get_metrics(request):
 
 def includeme(config):
     """Configure the /metrics view"""
-    metric_path_info = config.registry.settings.get(
-        'prometheus.metric_path_info', '/metrics')
+    metrics_path_info = config.registry.settings.get(
+        'prometheus.metrics_path_info', '/metrics')
 
-    config.add_route('prometheus_metric', metric_path_info)
+    config.add_route('prometheus_metric', metrics_path_info)
     config.add_view(
         get_metrics,
         route_name='prometheus_metric',


### PR DESCRIPTION
/metrics route should stand for metrics_path_info