### PR TITLE
Allow module to be included multiple times

### DIFF
--- a/gandi_pyramid_prometheus/prometheus.py
+++ b/gandi_pyramid_prometheus/prometheus.py
@@ -18,6 +18,11 @@ def includeme(config):
 
     global IS_MULTIPROC, pyramid_request, pyramid_request_ingress
 
+    # Early return in case this module is included more than once,
+    # otherwise registration of the metrics will fail with the prometheus lib
+    if pyramid_request is not None:
+        return
+
     settings = config.registry.settings
 
     IS_MULTIPROC = asbool(config.registry.settings.get(


### PR DESCRIPTION
This change allows `gandi-pyramid-prometheus` to be included multiple times inside a single process

For example during tests, in case multiple applications are using it

Otherwise the process will fail when registering the gauge / histogram the second time